### PR TITLE
patter: optional inverted-polarity mode (--five_base) for 5-Base / TAPS-style libraries

### DIFF
--- a/src/pipeline_wgbs/main.cpp
+++ b/src/pipeline_wgbs/main.cpp
@@ -31,7 +31,7 @@ int main(int argc, char **argv) {
             np_thresh = std::stof(np_thresh_str);
         }
         if (argc < 3) {
-            throw std::invalid_argument("Usage: patter CPG_DICT REGION [--mbias MBIAS_PATH] [--clip CLIP] [--nanopore] [--np_thresh NP_THRESH] [--cpc_call {C|H|.}] [--combine_mods] [--long]");
+            throw std::invalid_argument("Usage: patter CPG_DICT REGION [--mbias MBIAS_PATH] [--clip CLIP] [--nanopore] [--np_thresh NP_THRESH] [--cpc_call {C|H|.}] [--combine_mods] [--long] [--five_base]");
         }
         std::string mbias_path = input.getCmdOption("--mbias");
         bool is_np = input.cmdOptionExists("--nanopore");
@@ -48,6 +48,12 @@ int main(int argc, char **argv) {
         }
         bool combine_mods = input.cmdOptionExists("--combine_mods");
         patter p(argv[1], argv[2], mbias_path, min_cpg, clip, is_np, np_thresh, is_long, is_ds_test, cpc_call, combine_mods);
+        if (input.cmdOptionExists("--five_base")) {
+            // Inverted-polarity chemistry (Illumina 5-Base, TAPS): 5mC reads as T,
+            // unmethylated C stays C. Swap the meth/unmeth call characters.
+            p.OT = ReadOrient{'T', 'C', 0, 0};
+            p.OB = ReadOrient{'A', 'G', 1, 1};
+        }
         p.parse_reads_from_stdin();
 
     }

--- a/src/python/bam2pat.py
+++ b/src/python/bam2pat.py
@@ -143,7 +143,7 @@ def is_region_empty(view_cmd, region, verbose):
 
 def proc_chr(bam, out_path, region, genome, paired_end, ex_flags, in_flags, top_only, bottom_only,
              rg, mapq, debug, blueprint, clip, temp_dir, blacklist, whitelist, min_cpg, mbias, nanopore,
-             np_thresh, verbose, long, cpc_call='C', combine_mods=False):
+             np_thresh, verbose, long, cpc_call='C', combine_mods=False, five_base=False):
     """ Convert a temp single chromosome file, extracted from a bam file, into pat """
 
     # Run patter tool on a single chromosome (or region). out_path will have the following fields:
@@ -198,6 +198,8 @@ def proc_chr(bam, out_path, region, genome, paired_end, ex_flags, in_flags, top_
         patter_cmd += ' --combine_mods '
     if long:
         patter_cmd += ' --long '
+    if five_base:
+        patter_cmd += ' --five_base '
 
     if blueprint:
         patter_cmd, match_cmd = blueprint_legacy(genome, region, paired_end)
@@ -330,7 +332,7 @@ class Bam2Pat:
                        self.args.temp_dir, blist, wlist, self.args.min_cpg,
                        self.args.mbias, self.args.nanopore, self.args.np_thresh,
                        self.verbose, self.args.long,
-                       self.args.cpc_call, self.args.combine_mods)
+                       self.args.cpc_call, self.args.combine_mods, self.args.five_base)
                 params.append(par)
 
             if len(cur_regions) == 1 and self.args.threads == 1:
@@ -447,6 +449,10 @@ def parse_bam2pat_args(parser):
     parser.add_argument('--combine_mods', action='store_true',
                         help='Combine 5mC (C+m) and 5hmC (C+h) modifications, treating both as methylated. '
                              'Sums probabilities before thresholding. Output will contain only C/T/. (no H).')
+    parser.add_argument('--five_base', action='store_true',
+                        help='Input BAM is from an inverted-polarity chemistry (Illumina 5-Base, TAPS): '
+                             '5mC reads as T while unmethylated C stays C. Swaps the methylated/unmethylated '
+                             'call characters. Default behaviour without this flag is unchanged.')
 
 
 def add_samtools_view_flags(parser):


### PR DESCRIPTION
Hi Netanel — this adds an optional `--five_base` flag to `bam2pat`/`patter` for libraries where the chemistry runs the other way around: Illumina 5-Base (and TAPS-style protocols generally) convert **5mC → T** and leave unmethylated C alone, so on that data `patter`'s calls currently come out exactly inverted. With the flag, the methylated/unmethylated call characters are swapped; without it nothing changes — `.pat` output is byte-identical to current master (checked on real WGBS data and through a full `bam2pat` run). This came out of [FelixKrueger/Bismark#787](https://github.com/FelixKrueger/Bismark/issues/787), where a user pairing 5-Base and EM-seq arms through UXM hit the inversion — with this change his deconvolution works. Happy to adjust anything (flag name, plumbing style) to fit the codebase.

<details>
<summary>Why the two-constant swap is sufficient, and how it was validated (AI-assisted notes — skip freely)</summary>

**Why it's sufficient.** `ref_chr`/`unmeth_seq_chr` are read in exactly two places (`patter.cpp:153`, `:159`), both inside the call branch of `compareSeqToRef`, so swapping them inverts call polarity completely and touches nothing else. `is_cpg()` is polarity-agnostic — both branches accept either base, and the context bases it requires (`seq[j+1] == 'G'` for OT, `seq[j-1] == 'C'` for OB) are guanines on the read's own strand under 5-Base chemistry, hence never converted.

**The change.** The flag overrides the public `OT`/`OB` members after construction in `main.cpp` — no header or constructor change, so the default path is untouched by inspection. `bam2pat.py` gains the argparse option and passes it through to `patter`.

**Validation.**
- *Default path untouched:* with the patch present but the flag off, `.pat` output is byte-identical to master — `patter` standalone on real WGBS data (chr21, 59,250 pat lines, zero differences) and on a mixed-methylation synthetic PE fixture, plus a full `wgbstools bam2pat` run (decompressed `.pat.gz`).
- *The flag does exactly one thing:* on bisulfite input with `--five_base`, every output line is the exact C↔T mirror of the stock line — positions, CpG indices and counts unchanged (0 mismatches over those 59,250 lines).
- *Correct on 5-Base data:* on a fully CpG-methylated synthetic 5-Base dataset (aligner ground truth 100 %), stock `patter` calls 0.0 % methylation; with the flag, 100.0 % — each strand checked independently via the `--top_only`/`--bottom_only` selectors. And confirmed end-to-end through UXM on real paired 5-Base/EM-seq data by the user on the Bismark issue.

**Considered instead: the MM/ML path.** `patter` already routes base-modification tags to a modification-aware path, which would avoid the polarity question entirely — but `patter.cpp:341-343` rejects paired-end input there, and 5-Base libraries are paired-end. Lifting that restriction felt like a much bigger change than this flag.

**Scope.** No auto-detection — a wrong guess would silently invert every call, so explicit opt-in seemed safer. `add_cpg_counts.h` carries a copy of the same constants; `bam2pat` doesn't use it and this PR leaves it alone — happy to extend the flag there too if useful.

</details>
